### PR TITLE
bump version to get rid of security warnings 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>at.technikum</groupId>
@@ -60,7 +60,6 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.8.8</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
scheint irgendwie ein manuelles ding zu sein? idk. tutor nach howto gefragt letze woche. "google die aktuellen zahlen und schreib sie da rein" war paraphrasiert die antwort. ausweichend was den delete angeht.f